### PR TITLE
Refactor BuyNowPage calculations to align with backend logic, removin…

### DIFF
--- a/task/app/(pages)/buy-now/page.jsx
+++ b/task/app/(pages)/buy-now/page.jsx
@@ -59,7 +59,6 @@ export default function BuyNowPage() {
       0
     );
     const savings = mrpTotal - priceTotal;
-    const transactionFee = priceTotal > 0 ? 20 : 0;
     const deliveryFeeOriginal = priceTotal > 0 ? 165 : 0;
 
     // Group items by vendor
@@ -79,23 +78,46 @@ export default function BuyNowPage() {
       return groups;
     }, {});
 
+    // Calculate totals matching backend logic EXACTLY
+    const subtotal = priceTotal;
+    const discountAmount = 0; // No coupon applied
+    const taxAmount = (subtotal - discountAmount) * 0.18; // 18% GST on (subtotal - discount)
+    const shippingAmount = 0; // Free shipping
+    const totalAmount = subtotal - discountAmount + taxAmount + shippingAmount;
+
+    // Debug logging for calculation verification
+    console.log('Frontend Calculation Debug:', {
+      priceTotal,
+      subtotal,
+      discountAmount,
+      taxAmount,
+      shippingAmount,
+      totalAmount,
+      items: selectedItems.map(item => ({
+        name: item.name,
+        price: item.price,
+        quantity: item.quantity,
+        total: item.price * item.quantity
+      }))
+    });
+
     return {
       vendorGroups,
       subTotal: {
         label: "Sub total",
-        amount: priceTotal,
+        amount: subtotal,
         mrp: mrpTotal,
         icon: <Receipt />,
       },
       deliveryFee: {
         label: "Delivery fee",
-        amount: 0,
+        amount: shippingAmount,
         original: deliveryFeeOriginal,
         icon: <Truck />,
       },
-      transactionFee: {
-        label: "Transaction fee",
-        amount: transactionFee,
+      taxAmount: {
+        label: "Tax (18% GST)",
+        amount: taxAmount,
         icon: <Wallet />,
       },
       savings: {
@@ -105,7 +127,7 @@ export default function BuyNowPage() {
       },
       grandTotal: {
         label: "Grand Total",
-        amount: priceTotal + transactionFee,
+        amount: totalAmount,
       },
     };
   }, [selectedItems]);
@@ -284,7 +306,7 @@ export default function BuyNowPage() {
       // Configure payment options
       const options = {
         key: razorpayData.data.key_id,
-        amount: Math.round(razorpayData.data.total_amount * 100), // Convert to paise
+        amount: Math.round(Number(razorpayData.data.total_amount) * 100), // Convert to paise with proper conversion
         currency: razorpayData.data.currency,
         name: "Last Minute Deal",
         description: `Order ${razorpayData.data.order_number}`,


### PR DESCRIPTION
This pull request refines the `BuyNowPage` component in `task/app/(pages)/buy-now/page.jsx` by improving the accuracy of payment calculations, aligning frontend logic with backend standards, and enhancing debugging capabilities. The most important changes include removing the transaction fee, introducing detailed tax and shipping calculations, and ensuring proper type conversion for payment amounts.

### Calculation improvements:
* Removed the `transactionFee` logic and replaced it with a detailed breakdown of totals, including `subtotal`, `discountAmount`, `taxAmount` (18% GST), and `shippingAmount` (free shipping). This ensures the frontend calculations match the backend logic exactly. [[1]](diffhunk://#diff-23f644b888a93cd79a8e8e70c2c2b7c445dc8541e54770371e1a7761a36f4252L62) [[2]](diffhunk://#diff-23f644b888a93cd79a8e8e70c2c2b7c445dc8541e54770371e1a7761a36f4252R81-R120)
* Updated the `grandTotal` calculation to use the new `totalAmount` variable, which incorporates all components of the total.

### Debugging enhancements:
* Added a debug logging block to output detailed calculation data, including item details and intermediate totals, for verification purposes.

### Payment configuration:
* Fixed the type conversion for the payment `amount` to ensure proper handling of `razorpayData.data.total_amount` as a number before converting to paise.…g transaction fee and adding detailed logging for verification